### PR TITLE
Switch to released version of liberty maven plugin

### DIFF
--- a/consul-user-feature/consul-wlp/pom.xml
+++ b/consul-user-feature/consul-wlp/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>1.1-SNAPSHOT</version>
+                <version>1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverName>${wlpServerName}</serverName>


### PR DESCRIPTION
The 1.1 version of the plugin has been released, so we can use that
one, avoiding the need to configure an extra maven repository.
