### PR TITLE
Support optional port attribute

### DIFF
--- a/consul-user-feature/discovery.annotation.scanner/BundleContent/OSGI-INF/metatype/metatype.xml
+++ b/consul-user-feature/discovery.annotation.scanner/BundleContent/OSGI-INF/metatype/metatype.xml
@@ -18,6 +18,7 @@
 
 	<OCD name="consul-ocd" description="Configuration for the Consul server" id="consul-ocd">
 		<AD description="a consul server" id="server" type="String" />
+		<AD description="port for consul server" id="port" type="Integer" />
 	</OCD>
 
 	<Designate pid="consul.annotation.scanner">

--- a/consul-user-feature/discovery.annotation.scanner/src/main/java/net/wasdev/annotation/scanning/ConsulServicePublisher.java
+++ b/consul-user-feature/discovery.annotation.scanner/src/main/java/net/wasdev/annotation/scanning/ConsulServicePublisher.java
@@ -37,6 +37,11 @@ public class ConsulServicePublisher {
 		client = new ConsulClient(consulServer);
 	}
 
+	public ConsulServicePublisher(String consulServer, Integer consulPort) {
+		this.consulServer = consulServer;
+		client = new ConsulClient(consulServer, consulPort);
+	}
+
 	/**
 	 * Generates a unique name for a service but ensure that
 	 * if the same service is registered it will produce the same

--- a/consul-user-feature/discovery.annotation.scanner/src/main/java/net/wasdev/annotation/scanning/Scanner.java
+++ b/consul-user-feature/discovery.annotation.scanner/src/main/java/net/wasdev/annotation/scanning/Scanner.java
@@ -129,8 +129,13 @@ public class Scanner implements ModuleStateListener {
 		} else {
 			consulServer = consulEnv;
 		}
-		servicePublisher = new ConsulServicePublisher(consulServer);
-
+		if (cc.getProperties().get("port") != null)
+		{
+		    Integer consulPort = (Integer) cc.getProperties().get("port");
+		    servicePublisher = new ConsulServicePublisher(consulServer, consulPort);
+	    } else {
+    		servicePublisher = new ConsulServicePublisher(consulServer);
+		}
 	}
 
 	protected void modified(Map<?, ?> newProperties) {


### PR DESCRIPTION
If run in a Bluemix container group, the consul server will be on port
80, not the default of 8500, so support setting that in the config.
