### PR TITLE
Remove unused dependencies

### DIFF
--- a/consul-user-feature/discovery.annotation.scanner/BundleContent/META-INF/MANIFEST.MF
+++ b/consul-user-feature/discovery.annotation.scanner/BundleContent/META-INF/MANIFEST.MF
@@ -5,28 +5,17 @@ Bundle-SymbolicName: discovery.annotation.scanner
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/ScanningService.xml
-Import-Package: com.ibm.websphere.endpoint;version="1.0.0",
- com.ibm.websphere.servlet.event;version="1.1.0",
+Import-Package: com.ecwid.consul.transport;version="1.0.0",
+ com.ecwid.consul.v1;version="1.0.0",
+ com.ecwid.consul.v1.agent.model;version="1.0.0",
+ com.ibm.websphere.endpoint;version="1.0.0",
  com.ibm.ws.container.service.annotations;version="1.2.0",
  com.ibm.ws.container.service.app.deploy;version="1.2.0",
- com.ibm.ws.container.service.config;version="1.2.0",
- com.ibm.ws.container.service.metadata;version="1.0.0",
  com.ibm.ws.container.service.state;version="1.0.0",
  com.ibm.wsspi.adaptable.module;version="1.0.0",
- com.ibm.wsspi.adaptable.module.adapters;version="1.0.0",
- com.ibm.wsspi.anno.classsource;version="1.0.0",
  com.ibm.wsspi.anno.info;version="1.0.0",
- com.ibm.wsspi.anno.service;version="1.0.0",
  com.ibm.wsspi.anno.targets;version="1.0.0",
- com.ibm.wsspi.artifact;version="1.0.0",
- com.ibm.wsspi.artifact.overlay;version="1.1.0",
  javax.management,
  javax.ws.rs;version="2.0.0",
  javax.ws.rs.ext;version="2.0.0",
- javax.net,
- javax.net.ssl,
- org.osgi.framework;version="1.7.0",
- org.osgi.service.component;version="1.2.0",
- com.ecwid.consul.transport;version="1.0.0",
- com.ecwid.consul.v1;version="1.0.0",
- com.ecwid.consul.v1.agent.model;version="1.0.0"
+ org.osgi.service.component;version="1.2.0"


### PR DESCRIPTION
It looks like a workaround for a dependency issue is now no longer
required, and there are a lot of unused package imports.
