### PR TITLE
Set interval for health check, use endpoint, not context root

### DIFF
--- a/consul-user-feature/discovery.annotation.scanner/src/main/java/net/wasdev/annotation/scanning/ConsulServicePublisher.java
+++ b/consul-user-feature/discovery.annotation.scanner/src/main/java/net/wasdev/annotation/scanning/ConsulServicePublisher.java
@@ -87,13 +87,13 @@ public class ConsulServicePublisher {
 
 			// Add a health check, in case the service doesn't exit gracefully
 			NewService.Check check = new NewService.Check();
-			// We assume nothing important happens when pinging the application
-			// path
-			String pingableAddress = hostAddress + ":" + endpoint.getPort()
+			// We assume nothing too expensive or interesting happens when doing a get on an endpoint
+			String endpointAddress = hostAddress + ":" + endpoint.getPort()
 					+ endpoint.getHealthCheckPath();
 			System.out.println("Registering consul health check at "
-					+ pingableAddress);
-			check.setHttp(pingableAddress);
+					+ endpointAddress);
+			check.setInterval("30s");
+			check.setHttp("http://" + endpointAddress);
 			service.setCheck(check);
 
 			// register new service

--- a/consul-user-feature/discovery.annotation.scanner/src/main/java/net/wasdev/annotation/scanning/Endpoint.java
+++ b/consul-user-feature/discovery.annotation.scanner/src/main/java/net/wasdev/annotation/scanning/Endpoint.java
@@ -41,6 +41,8 @@ public class Endpoint {
 	private String healthCheckPath = "/";
 
 	public Endpoint(String configuredHost, int configuredPort, String path, String name) {
+		// Sanitise out any double slashes
+		path = path.replaceAll("//", "/");
 		this.path = path;
 
 		// If we're running in Bluemix, read the environment
@@ -143,7 +145,7 @@ public class Endpoint {
 	 * be prefixed with '/'.
 	 */
 	public void setHealthCheckPath(String applicationPath) {
-		this.healthCheckPath = applicationPath;
+		this.healthCheckPath = applicationPath.replaceAll("//", "/");
 	}
 
 	@Override

--- a/consul-user-feature/discovery.annotation.scanner/src/main/java/net/wasdev/annotation/scanning/RestModule.java
+++ b/consul-user-feature/discovery.annotation.scanner/src/main/java/net/wasdev/annotation/scanning/RestModule.java
@@ -18,14 +18,20 @@ package net.wasdev.annotation.scanning;
 
 import java.lang.annotation.Annotation;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.ext.Provider;
 
 import com.ibm.ws.container.service.annotations.WebAnnotations;
-import com.ibm.wsspi.anno.info.*;
+import com.ibm.wsspi.anno.info.AnnotationInfo;
+import com.ibm.wsspi.anno.info.AnnotationValue;
+import com.ibm.wsspi.anno.info.ClassInfo;
+import com.ibm.wsspi.anno.info.InfoStore;
+import com.ibm.wsspi.anno.info.MethodInfo;
 import com.ibm.wsspi.anno.targets.AnnotationTargets_Targets;
 
 public class RestModule {
@@ -36,8 +42,7 @@ public class RestModule {
 		return endpoints;
 	}
 
-	public RestModule(String host, int port, String contextRoot,
-			WebAnnotations webAnnotations) {
+	public RestModule(String host, int port, String contextRoot, WebAnnotations webAnnotations) {
 		try {
 			InfoStore infoStore = webAnnotations.getInfoStore();
 
@@ -46,40 +51,33 @@ public class RestModule {
 			// Ignore all complexities like @Parent annotations for the moment,
 			// and also inheritance.
 
-			AnnotationTargets_Targets annotationTargets = webAnnotations
-					.getAnnotationTargets();
+			AnnotationTargets_Targets annotationTargets = webAnnotations.getAnnotationTargets();
 
 			String applicationPath = "";
 			Set<String> classesWithApplicationPath = annotationTargets
-					.getAnnotatedClasses(ApplicationPath.class.getName(),
-							POLICY_SEED);
+					.getAnnotatedClasses(ApplicationPath.class.getName(), POLICY_SEED);
 			if (classesWithApplicationPath.size() == 0) {
-				System.err
-						.println("The REST application path must be set using annotations. ");
+				System.err.println("The REST application path must be set using annotations. ");
 			} else if (classesWithApplicationPath.size() > 1) {
-				System.err
-						.println("There should only be one REST application path per application.");
+				System.err.println("There should only be one REST application path per application.");
 			} else {
 				applicationPath = getValue(infoStore, ApplicationPath.class,
 						classesWithApplicationPath.iterator().next());
 			}
 
 			// Scan annotation for @Provider, @Path
-			processAnnotations(host, port, contextRoot, infoStore,
-					annotationTargets, Provider.class, applicationPath);
-			processAnnotations(host, port, contextRoot, infoStore,
-					annotationTargets, Path.class, applicationPath);
+			processAnnotations(host, port, contextRoot, infoStore, annotationTargets, Provider.class, applicationPath);
+			processAnnotations(host, port, contextRoot, infoStore, annotationTargets, Path.class, applicationPath);
 
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
 	}
 
-	private void processAnnotations(String host, int port, String contextRoot,
-			InfoStore infoStore, AnnotationTargets_Targets annotationTargets,
-			Class<? extends Annotation> annotationClass, String applicationPath) {
-		Set<String> annotatedClasses = annotationTargets.getAnnotatedClasses(
-				Path.class.getName(), POLICY_SEED);
+	private void processAnnotations(String host, int port, String contextRoot, InfoStore infoStore,
+			AnnotationTargets_Targets annotationTargets, Class<? extends Annotation> annotationClass,
+			String applicationPath) {
+		Set<String> annotatedClasses = annotationTargets.getAnnotatedClasses(Path.class.getName(), POLICY_SEED);
 		for (String s : annotatedClasses) {
 			String path = getValue(infoStore, Path.class, s);
 
@@ -88,32 +86,57 @@ public class RestModule {
 			// 'extra' information
 
 			String uri = contextRoot + applicationPath;
-			if(path.charAt(0) != '/') {
-				//spec states that leading /'s are ignored, but doesn't stop it being declared, so check
+			if (path.charAt(0) != '/') {
+				// spec states that leading /'s are ignored, but doesn't stop it
+				// being declared, so check
 				uri += "/";
 			}
 			uri += path;
-			
-			//use the name of the class as the name of the service to register
+
+			// use the name of the class as the name of the service to register
 			int pos = s.lastIndexOf('.');
 			String name = (pos == -1) ? s : s.substring(pos + 1);
-			
+
 			Endpoint newEndpoint = new Endpoint(host, port, uri, name);
 
-			// Hitting a rest endpoint might have an action, so lets just
-			// check the server is up occasionally. If it stops gracefully,
-			// it will unregister the application, if it's not graceful,
-			// this will catch that.
-			newEndpoint.setHealthCheckPath("/");
+			String restGetPath = findRestGetEndpoint(infoStore, s);
+			if (restGetPath != null) {
+				// The health check will need to hit an endpoint
+				newEndpoint.setHealthCheckPath(uri + "/" + restGetPath);
+			}
 			endpoints.add(newEndpoint);
 		}
 	}
 
-	private String getValue(InfoStore infoStore,
-			Class<? extends Annotation> annotationClass, String s) {
-		ClassInfo i = infoStore.getDelayableClassInfo(s);
+	private String getValue(InfoStore infoStore, Class<? extends Annotation> annotationClass, String className) {
+		ClassInfo i = infoStore.getDelayableClassInfo(className);
 		AnnotationInfo info = i.getAnnotation(annotationClass);
 		AnnotationValue path = info.getValue("value");
 		return path.getStringValue();
+	}
+
+	/**
+	 * Searches the methods on an class to find the first one with a GET
+	 * annotation, and then returns its path.
+	 * 
+	 * @return
+	 */
+	private String findRestGetEndpoint(InfoStore infoStore, String className) {
+		ClassInfo i = infoStore.getDelayableClassInfo(className);
+		List<? extends MethodInfo> ms = i.getMethods();
+		for (MethodInfo m : ms) {
+			AnnotationInfo getAnInf = m.getAnnotation(GET.class);
+			if (getAnInf != null) {
+				AnnotationInfo pathAnInf = m.getAnnotation(Path.class);
+				if (pathAnInf != null) {
+					AnnotationValue path = pathAnInf.getValue("value");
+					return path.getStringValue();
+				} else {
+					// This is a get endpoint with no extra path
+					return "";
+				}
+			}
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
The health check wasn't working properly, because it looks like it won't run unless an interval is set explicitly. When it does run, it will need to hit an endpoint which returns a 200 code, not a 4-- code, so I've added extra scanning to find a proper GET-annotated method.
There are also some whitespace changes.
